### PR TITLE
Apply TypeScript constructor during componentWillMount.

### DIFF
--- a/src/create_class.ts
+++ b/src/create_class.ts
@@ -5,6 +5,7 @@ function createClass<P, S>(
     createClass: ClassCreator<P, S>,
     clazz: ComponentClass<P, S>): React.ReactComponentFactory<P> {
     var displayName = clazz.prototype.constructor.name;
+    var componentWillMount = clazz.prototype.componentWillMount;
     // Do not override React
     delete clazz.prototype.constructor;
     delete clazz.prototype.getDOMNode;
@@ -17,6 +18,12 @@ function createClass<P, S>(
     delete clazz.prototype.replaceProps;
     var spec: React.Specification<P, S> = clazz.prototype;
     spec.displayName = displayName;
+    spec.componentWillMount = function() {
+        clazz.apply(this);
+        if (componentWillMount) {
+            componentWillMount.apply(this);
+        }
+    };
     return createClass(spec);
 }
 

--- a/test/create_class_spec.ts
+++ b/test/create_class_spec.ts
@@ -13,8 +13,10 @@ interface FactoryState {
 }
 
 class FactoryTest extends TypedReact.Component<FactoryProps, FactoryState> {
+    greeting: string = "Greetings, ";
+
     render() {
-        return React.DOM.h1(null, "Greetings", name);
+        return React.DOM.h1(null, this.greeting, this.props.name);
     }
 }
 
@@ -35,5 +37,9 @@ describe("createFactory", () => {
     it("should produce a valid descriptor", () => {
         expect(React.isValidElement(descriptor)).to.be.true;
         expect(descriptor.props.name).to.equal(name);
+    });
+
+    it("should keep class properties", () => {
+        expect(React.renderToStaticMarkup(factory({name: "Asana"}))).to.equal("<h1>Greetings, Asana</h1>");
     });
 });


### PR DESCRIPTION
This patch makes components created with TypedReact.createClass run a component
class' constructor as part of componentWillMount. This allows for more idiomatic
TypeScript by supporting constructors and properties with initializers (see test).
