### PR TITLE
Changing component class to take React.Spec

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,9 +28,9 @@ gulp.task('build', ['bundle']);
 
 gulp.task('bundle', ['copy'], function() {
   dts.bundle({
+    externals: true,
     name: 'typed-react',
-    main: files.dts,
-    removeSource: true
+    main: files.dts
   });
 });
 

--- a/src/component_class.ts
+++ b/src/component_class.ts
@@ -1,7 +1,5 @@
-import Component = require("./component");
-
 interface ComponentClass<P, S> {
-    new (): Component<P, S>
+    new (): React.Specification<P, S>
 }
 
 export = ComponentClass;


### PR DESCRIPTION
This is so that way we can actually take any class that matches the
React Specification.
