### PR TITLE
Adding inheritance support to createClass

### DIFF
--- a/test/create_class_spec.ts
+++ b/test/create_class_spec.ts
@@ -20,6 +20,9 @@ class FactoryTest extends TypedReact.Component<FactoryProps, FactoryState> {
     }
 }
 
+class InheritanceTest extends FactoryTest {
+}
+
 describe("createFactory", () => {
     var clazz: React.ReactComponentFactory<FactoryProps>;
     var factory: React.ReactComponentFactory<FactoryProps>;
@@ -41,5 +44,11 @@ describe("createFactory", () => {
 
     it("should keep class properties", () => {
         expect(React.renderToStaticMarkup(factory({name: "Asana"}))).to.equal("<h1>Greetings, Asana</h1>");
+    });
+
+    it("should keep inherited methods and props", () => {
+        var inheritedClazz = TypedReact.createClass<FactoryProps, FactoryState>(React.createClass, InheritanceTest);
+        var inheritedFactory = React.createFactory(inheritedClazz);
+        expect(React.renderToStaticMarkup(inheritedFactory({name: "Asana"}))).to.equal("<h1>Greetings, Asana</h1>");
     });
 });


### PR DESCRIPTION
Before, we did not support inherited properties which was surprising and
an unpleasant developer experience. Using for ... in solves that problem
but is much slower. Fortunately we should only be creating classes once
per run time.
