### PR TITLE
add reference to typings in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ npm install typed-react --save
 ## Example
 
 ```ts
+/// <reference path='../path/to/react.d.ts' />
+/// <reference path='../path/to/typed-react.d.ts' />
+
 import React = require("react");
 import TypedReact = require("typed-react");
 


### PR DESCRIPTION
Hi,

For people trying this out who might be more familiar with react than typescript, they may run into this when trying the example:

``` sh
TS2071: Unable to resolve external module ''react''.
```

This might confuse them and possibly turn them away. I added a reference to the typings for react and react-typed in the code example. I hope this can help clarify that the typescript compiler needs to know these in order to import at compile time.

I hope this helps.

Thanks,
Mike
