### PR TITLE
Make CSSTransitionGroup usable

### DIFF
--- a/typings/react/react.d.ts
+++ b/typings/react/react.d.ts
@@ -661,8 +661,8 @@ declare module React {
         childFactory?: (child: ReactElement<any>) => ReactElement<any>;
     }
 
-    interface CSSTransitionGroup extends ComponentClass<CSSTransitionGroupProps> {}
-    interface TransitionGroup extends ComponentClass<TransitionGroupProps> {}
+    interface CSSTransitionGroup extends Factory<CSSTransitionGroupProps> {}
+    interface TransitionGroup extends Factory<TransitionGroupProps> {}
 
     //
     // React.addons (Mixins)


### PR DESCRIPTION
In current code `CSSTransitionGroup` is not usable because of the deprecation on https://github.com/Asana/typed-react/blob/master/typings/react/react.d.ts#L45. Let's make it usable!