### PR TITLE
Update to React v0.13 typings

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -76,7 +76,7 @@ register(Task.clean, [], (callback) => {
  */
 register(Task.copy, [Task.scripts], () => {
     return gulp.src(path.join(dirs.build, dirs.src, match(set(".d.ts", ".js"))))
-        .pipe(replace("/// <reference path=\"../typings/react/react.d.ts\" />", ""))
+        .pipe(replace("<reference path=\"../", "<reference path=\"./"))
         .pipe(gulp.dest(dirs.cwd));
 });
 
@@ -120,6 +120,7 @@ register(Task.scripts, [Task.clean], (callback) => {
           sortOutput: false,
           target: "ES5"
       }));
+
     drain(compiler.js);
     drain(compiler.dts);
     function drain(stream: NodeJS.ReadWriteStream): void {

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,8 +1,10 @@
 /// <reference path="../typings/react/react.d.ts"/>
-import Mixin = require("././mixin");
 
-class Component<P, S> extends Mixin<P, S> implements React.CompositeComponent<P, S> {
-    render(): React.ReactElement<any> {
+import Mixin = require("././mixin");
+import react = require("react");
+
+class Component<P, S> extends Mixin<P, S> implements react.ClassicComponent<P, S> {
+    render(): react.ReactElement<any> {
         return null;
     }
 }

--- a/src/create_class.ts
+++ b/src/create_class.ts
@@ -3,8 +3,8 @@ import extractPrototype = require("./extract_prototype");
 import Component = require("./component");
 import react = require("react");
 
-function createClass<P, S>(clazz: { new(): Component<P, S> }, mixins?: React.Mixin<P, S>[]): React.ComponentClass<P> {
-    var spec: React.ComponentSpec<P, S> = extractPrototype(clazz);
+function createClass<P, S>(clazz: { new(): Component<P, S> }, mixins?: react.Mixin<P, S>[]): react.ComponentClass<P> {
+    var spec: react.ComponentSpec<P, S> = extractPrototype(clazz);
     spec.displayName = clazz.prototype.constructor.name;
     if (spec.componentWillMount !== undefined) {
         var componentWillMount = spec.componentWillMount;

--- a/src/create_mixin.ts
+++ b/src/create_mixin.ts
@@ -1,8 +1,9 @@
 /// <reference path="../typings/react/react.d.ts"/>
 import extractPrototype = require("./extract_prototype");
 import Mixin = require("./mixin");
+import react = require("react");
 
-function createMixin<P, S>(clazz: { new(): Mixin<P, S> }): React.Mixin<P, S> {
+function createMixin<P, S>(clazz: { new(): Mixin<P, S> }): react.Mixin<P, S> {
     return extractPrototype(clazz);
 }
 

--- a/src/mixin.ts
+++ b/src/mixin.ts
@@ -1,18 +1,20 @@
 /// <reference path="../typings/react/react.d.ts"/>
 import NotImplementedError = require("./not_implemented_error");
+import react = require("react");
 
-class Mixin<P, S> implements React.Mixin<P, S> {
+class Mixin<P, S> implements react.Mixin<P, S> {
     public refs: {
-        [key: string]: React.Component<any>
+        [key: string]: react.Component<any, any>
     };
     public props: P;
     public state: S;
+    public context: any;
 
     getDOMNode(): Element {
         throw new NotImplementedError("getDomNode");
     }
 
-    setState(nextState: S, callback?: () => void): void {
+    setState(nextState: S | ((prevState: S, props: P) => S), callback?: () => void): void {
         throw new NotImplementedError("setState");
     }
 

--- a/test/create_class_spec.ts
+++ b/test/create_class_spec.ts
@@ -1,4 +1,6 @@
 /// <reference path="../typings/mocha/mocha.d.ts" />
+/// <reference path="../typings/react/react.d.ts" />
+
 import chai = require("chai");
 import React = require("react");
 import TypedReact = require("../src/index");
@@ -37,13 +39,13 @@ class LifeCycleMixin extends TypedReact.Mixin<FactoryProps, FactoryState> {
 }
 
 class HelperMixin extends TypedReact.Mixin<FactoryProps, FactoryState> {
-    greet(greeting: string): React.ReactHTMLElement {
+    greet(greeting: string): React.HTMLElement {
         return React.DOM.h1(null, greeting, this.props.name);
     }
 }
 
 class MixinTest extends FactoryTest implements HelperMixin {
-    greet: (greeting: string) => React.ReactHTMLElement;
+    greet: (greeting: string) => React.HTMLElement;
 
     render() {
         return this.greet(this.greeting);
@@ -52,7 +54,7 @@ class MixinTest extends FactoryTest implements HelperMixin {
 
 describe("createFactory", () => {
     var clazz: React.ComponentClass<FactoryProps>;
-    var factory: React.ComponentFactory<FactoryProps>;
+    var factory: React.Factory<FactoryProps>;
     var element: React.ReactElement<FactoryProps>;
     var name = "test";
 

--- a/tsd.json
+++ b/tsd.json
@@ -51,7 +51,7 @@
       "commit": "b5131a650f037aa1d962b9ff63a1bb929dc2dcf7"
     },
     "react/react.d.ts": {
-      "commit": "b5131a650f037aa1d962b9ff63a1bb929dc2dcf7"
+      "commit": "57340eca1e3aac68d59cc981b441da834ca38235"
     },
     "vinyl/vinyl.d.ts": {
       "commit": "b5131a650f037aa1d962b9ff63a1bb929dc2dcf7"


### PR DESCRIPTION
This updates typed-react to work with the current React v0.13 typings from DefinitelyTyped

The main change is that the current typings declare an external "react" module rather than declaring React in the global namespace, although both flavors of the typings are available in the DefinitelyTyped repository.

Although it is possible to skip typed-react and just use ES6 classes directly, this is still helpful for places where mixin support is useful since that story hasn't been figured out yet, and in my case for migrating a reasonable-size existing codebase to ES6 classes.

 * The main React typings for v0.13 declare an
   external module rather than one which declares
   the internal module React in the global namespace.

 * Adjust the '<reference path' lines in the .d.ts files generated
   by TypeScript rather than removing them, as dts-bundle
   now needs to know about them

See #45