### PR TITLE
Bump React dev dependency to v0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gulp-tslint": "^1.3.0",
     "gulp-typedoc": "^1.1.0",
     "gulp-typescript": "^2.1.0",
-    "react": "^0.12.1",
+    "react": "^0.13.0",
     "tsd": "^0.6.0-beta.5",
     "typescript-require": "https://github.com/pspeter3/typescript-require/releases/download/v1.0.6/typescript-require-1.0.6.tgz"
   },


### PR DESCRIPTION
The typings have now been updated for React v0.13, update
the version used during development as well.